### PR TITLE
Set connector_id to 0

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -456,9 +456,7 @@ function _accountsync_create_account_contact($contactID, $createNew, $connector_
   $accountContact = array('contact_id' => $contactID);
   foreach (_accountsync_get_enabled_plugins() as $plugin) {
     $accountContact['plugin'] = $plugin;
-    if ($connector_id) {
-      $accountContact['connector_id'] = $connector_id;
-    }
+    $accountContact['connector_id'] = $connector_id;
     try {
       $accountContact['id'] = civicrm_api3('account_contact', 'getvalue', array_merge($accountContact, array('return' => 'id')));
       $accountContact['accounts_needs_update'] = 1;


### PR DESCRIPTION
Eileen, I'm not exactly sure how you plan using connector_id's, so please treat this PR as a place-holder for an issue rather than a fix.

What I was finding was that when I create a CiviCRM contribution, the civicrm_account_contact record was created with connector_id set to NULL. The Push job was looking for records with connector_id set to '0' (zero). This change sets the connector_id column to zero when a row is created.

I was tempted to make a change to the API that checked whether connector_id was set, but wondered whether that might be too late. As this bit of code knew about connector_id it seemed the place to change. The CiviXero extension may need to change as well, unless it is the API that needs changing (eg, the REST call for "Queue sync to Xero" on the contact summary screen does not set connector_id).