### PR TITLE
When deduping contacts, there is no need to delete account_contact

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -533,7 +533,6 @@ function accountsync_civicrm_merge($type, $data, $new_id = NULL, $old_id = NULL,
       //@todo - this will only move old contact ref to the new one - if both have xero accounts
       // then it will fail
       $accountContact = civicrm_api3('account_contact', 'getsingle', array('plugin' => 'xero', 'contact_id' => $old_id));
-      civicrm_api3('account_contact', 'delete', array('contact_id' => $old_id));
       $accountContact['contact_id'] = $new_id;
       civicrm_api3('account_contact', 'create', $accountContact);
     }


### PR DESCRIPTION
Eileen,

When testing the merging of duplicate CiviCRM contacts, the account_contact 'delete' (accountsync.php, line 538) was throwing an exception as the $params needed to include elements for 'id', 'plugin' and 'connector_id'. In addition, when doing the account_contact 'create' on line 540 I found I needed to unset $accountContact['id'] so the 'create' did a 'create' rather than an 'edit'.

So this PR is a suggestion to remove the 'delete' on line 538.

What that means is that rather than creating a new account_contact with the same details as the one that was deleted, this change would simply update the existing account_contact with the $new_id.

It seems to work, but is there a side-effect I'm ignoring?