### PR TITLE
Handle case when the Payment Instrument is not set

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -100,10 +100,15 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
 
     $instrumentFinancialAccounts = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount();
     $contribution['payment_instrument_financial_account_id'] = $instrumentFinancialAccounts[$contribution['payment_instrument_id']];
-    $contribution['payment_instrument_accounting_code'] = civicrm_api3('financial_account', 'getvalue', array(
-      'id' => $contribution['payment_instrument_financial_account_id'],
-      'return' => 'accounting_code',
-    ));
+    try {
+      $contribution['payment_instrument_accounting_code'] = civicrm_api3('financial_account', 'getvalue', array(
+        'id' => $contribution['payment_instrument_financial_account_id'],
+        'return' => 'accounting_code',
+      ));
+    }
+    catch(Exception $e) {
+      ;
+    }
 
     return array($contribution['id'] => $contribution);
   }


### PR DESCRIPTION
When pushing an Invoice to Xero, the code fails if the Contribution's Payment Instrument is not set.

This happens in the case when an online contribution is made to "Pay later".

This change simply catches the exception from the CiviCRM API and does nothing.

This is satisfactory for Invoices, since they don't use the 'payment_instrument_accounting_code' value. Some further work may be needed for Bank Transactions, which do use it.