### PR TITLE
API call to 'contribution' 'set_value' creates errant AccountContact records

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -203,3 +203,17 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
   }
 
 }
+
+/**
+ * Get the accounting code from the financial type id.
+ *
+ * @param int $financialTypeID
+ * @return mixed
+ */
+function tapestrymultiaccounts_get_civicrm_account_code($financialTypeID) {
+  static $codes = array();
+  if (!in_array($financialTypeID, $codes)) {
+    $codes[$financialTypeID] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
+  }
+  return $codes[$financialTypeID];
+}

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -145,7 +145,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
   /**
    * Update contributions in civicrm based on their status in Xero.
    */
-  protected static function completeContributionFromAccountsStatus() {
+  static function completeContributionFromAccountsStatus() {
     $sql = "
       SELECT contribution_id
       FROM civicrm_account_invoice cas
@@ -164,7 +164,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
    *
    * @todo - I don't believe this will adequately cancel related entities
    */
-  protected static function cancelContributionFromAccountsStatus($params) {
+  static function cancelContributionFromAccountsStatus($params) {
     //get pending registrations
     $sql = "SELECT  cas.contribution_id
       FROM civicrm_account_invoice cas

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -214,24 +214,3 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
   }
 
 }
-
-/**
- * Get the accounting code from the financial type id.
- *
- * @param int $financialTypeID
- * @return mixed
- */
-function tapestrymultiaccounts_get_civicrm_account_code($financialTypeID) {
-  static $codes = array();
-  if (!in_array($financialTypeID, $codes)) {
-    $codes[$financialTypeID] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
-    if (empty($codes[$financialTypeID])) {
-      $codes[$financialTypeID] = civicrm_api('setting', 'getvalue', array(
-        'group' => 'Xero Settings',
-        'name' => 'xero_default_revenue_account',
-        'version' => 3,
-      ));
-    }
-  }
-  return $codes[$financialTypeID];
-}

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -214,6 +214,13 @@ function tapestrymultiaccounts_get_civicrm_account_code($financialTypeID) {
   static $codes = array();
   if (!in_array($financialTypeID, $codes)) {
     $codes[$financialTypeID] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($financialTypeID);
+    if (empty($codes[$financialTypeID])) {
+      $codes[$financialTypeID] = civicrm_api('setting', 'getvalue', array(
+        'group' => 'Xero Settings',
+        'name' => 'xero_default_revenue_account',
+        'version' => 3,
+      ));
+    }
   }
   return $codes[$financialTypeID];
 }

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -94,10 +94,15 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     }
     $instrumentFinancialAccounts = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount();
     $contribution['payment_instrument_financial_account_id'] = $instrumentFinancialAccounts[$contribution['payment_instrument_id']];
-    $contribution['payment_instrument_accounting_code'] = civicrm_api3('financial_account', 'getvalue', array(
-      'id' => $contribution['payment_instrument_financial_account_id'],
-      'return' => 'accounting_code',
-    ));
+    try {
+      $contribution['payment_instrument_accounting_code'] = civicrm_api3('financial_account', 'getvalue', array(
+        'id' => $contribution['payment_instrument_financial_account_id'],
+        'return' => 'accounting_code',
+      ));
+    }
+    catch(Exception $e) {
+      ;
+    }
 
     return array($contribution['id'] => $contribution);
   }

--- a/accountsync.php
+++ b/accountsync.php
@@ -533,8 +533,6 @@ function accountsync_civicrm_merge($type, $data, $new_id = NULL, $old_id = NULL,
       //@todo - this will only move old contact ref to the new one - if both have xero accounts
       // then it will fail
       $accountContact = civicrm_api3('account_contact', 'getsingle', array('plugin' => 'xero', 'contact_id' => $old_id));
-//      civicrm_api3('account_contact', 'delete', $accountContact);
-//      unset($accountContact['id']);
       $accountContact['contact_id'] = $new_id;
       civicrm_api3('account_contact', 'create', $accountContact);
     }

--- a/accountsync.php
+++ b/accountsync.php
@@ -533,7 +533,8 @@ function accountsync_civicrm_merge($type, $data, $new_id = NULL, $old_id = NULL,
       //@todo - this will only move old contact ref to the new one - if both have xero accounts
       // then it will fail
       $accountContact = civicrm_api3('account_contact', 'getsingle', array('plugin' => 'xero', 'contact_id' => $old_id));
-      civicrm_api3('account_contact', 'delete', array('contact_id' => $old_id));
+//      civicrm_api3('account_contact', 'delete', $accountContact);
+//      unset($accountContact['id']);
       $accountContact['contact_id'] = $new_id;
       civicrm_api3('account_contact', 'create', $accountContact);
     }


### PR DESCRIPTION
When the CiviCRM API calls 'contribution' 'set_value' there is no need for the caller to pass in the 'contact_id'. However, accountsync_civicrm_post() expects this to be set for Contributions.

The outcome was that AccountContact records were being created where the Contact Id was actually a Contribution Id.

This change

 - recognises $objectRef->id may not be a Contact Id, but may be a Contribution Id
 - adds switch cases for when $objectName is 'LineItem', 'Contribution' and 'Contact'
 - will not create an AccountContact is no Contact Id can be found

You should review and see if cases are needed for 'Email' etc.