### PR TITLE
Refs #17. Check we have accounting code & related contact 

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -202,15 +202,18 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
   public static function getAccountsContact($financialTypeID) {
     static $contacts = array();
     if (!in_array($financialTypeID, $contacts)) {
-      $accountingCode = self::getAccountCode($financialTypeID);
-      $contacts[$financialTypeID] = CRM_Core_DAO::singleValueQuery(
-        "SELECT contact_id FROM civicrm_financial_account
-         WHERE accounting_code = %1
-        ",
-        array(1 => array($accountingCode, 'String'))
-      );
+      if ($accountingCode = self::getAccountCode($financialTypeID)) {
+        $contacts[$financialTypeID] = CRM_Core_DAO::singleValueQuery(
+          "SELECT contact_id FROM civicrm_financial_account
+           WHERE accounting_code = %1
+          ",
+          array(1 => array($accountingCode, 'String'))
+        );
+        if (isset($contacts[$financialTypeID])) {
+          return $contacts[$financialTypeID];
+        }
+      }
     }
-    return $contacts[$financialTypeID];
   }
 
   /**


### PR DESCRIPTION
In CRM_Accountsync_BAO_AccountInvoice::getAccountsContact(), would generate invalid SQL and throw a fatal error if there was no accounting code or related contact for same.

This patch checks that and no value is returned if not found.

GH-17, RM-10229
