### PR TITLE
Implement plugin mechanism

### DIFF
--- a/CRM/Accountsync/Job/job.mgd.php
+++ b/CRM/Accountsync/Job/job.mgd.php
@@ -4,36 +4,4 @@
 // database as appropriate. For more details, see "hook_civicrm_managed" at:
 // http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
 return array (
-  0 =>
-  array (
-    'name' => 'CiviAccountSync Complete Contributions From Accounts',
-    'entity' => 'Job',
-    'params' =>
-    array (
-      'version' => 3,
-      'name' => 'CiviAccountSync Complete Contributions',
-      'description' => 'Complete Contributions in CiviCRM where completed in Accounts',
-      'api_entity' => 'AccountInvoice',
-      'api_action' => 'update_contribution',
-      'run_frequency' => 'Always',
-      'parameters' => 'plugin=xero
-accounts_status_id=1',
-    ),
-  ),
-  1 =>
-  array (
-    'name' => 'CiviAccountSync Cancel Contributions From Accounts',
-    'entity' => 'Job',
-    'params' =>
-    array (
-      'version' => 3,
-      'name' => 'CiviAccountSync Cancel Contributions',
-      'description' => 'Cancel Contributions in CiviCRM where cancelled in Accounts',
-      'api_entity' => 'AccountInvoice',
-      'api_action' => 'update_contribution',
-      'run_frequency' => 'Always',
-      'parameters' => 'plugin=xero
-       accounts_status_id=3',
-    ),
-  ),
 );

--- a/accountsync.php
+++ b/accountsync.php
@@ -534,13 +534,24 @@ function _accountsync_map_object_name_to_entity($objectName) {
   }
   return $objectName;
 }
+
 /**
  * Get array of enabled plugins.
  *
  * Currently we don't have a mechanism for this & are just returning xero.
  */
 function _accountsync_get_enabled_plugins() {
-  return array('xero');
+  static $plugins = array();
+
+  if (empty($plugins)) {
+    /* Use the CiviCRM hook system to get a list of plugins.
+     * This is largely undocumented, so just following the pattern of built-in
+     * hooks.
+     */
+    CRM_Utils_Hook::singleton()->invoke(1, $plugins, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, 'civicrm_accountsync_plugins');
+  }
+
+  return $plugins;
 }
 
 /**

--- a/accountsync.php
+++ b/accountsync.php
@@ -460,26 +460,28 @@ function accountsync_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function _accountsync_handle_contact_deletion($op, $entity, $id, &$params) {
   if (($op == 'delete' || $op == 'trash' || ($op == 'update' && !empty($params['is_deleted']))) && ($entity == 'Contact')) {
-    try {
-      $accountContact = civicrm_api3('account_contact', 'getsingle', array(
-        'contact_id' => $id,
-        'plugin' => 'xero')
-      );
+    foreach(_accountsync_get_enabled_plugins() as $plugin) {
+      try {
+        $accountContact = civicrm_api3('account_contact', 'getsingle', array(
+          'contact_id' => $id,
+          'plugin' => $plugin)
+        );
 
-      if (empty($accountContact['accounts_contact_id'])) {
-        civicrm_api3('account_contact', 'delete', array('id' => $accountContact['id']));
-      }
-      elseif ($op == 'trash' || $op == 'update') {
-        CRM_Core_Session::setStatus(ts('You are deleting a contact that has been synced to your accounts system. It is recommended you restore the contact & fix this'));
-      }
-      else {
-        civicrm_api3('account_contact', 'delete', array('id' => $accountContact['id']));
-        CRM_Core_Session::setStatus(ts('You have deleted a contact that has been synced to your accounts system. The sync tracking record has been deleted. Resolution is unclear'));
+        if (empty($accountContact['accounts_contact_id'])) {
+          civicrm_api3('account_contact', 'delete', array('id' => $accountContact['id']));
+        }
+        elseif ($op == 'trash' || $op == 'update') {
+          CRM_Core_Session::setStatus(ts('You are deleting a contact that has been synced to your accounts system. It is recommended you restore the contact & fix this'));
+        }
+        else {
+          civicrm_api3('account_contact', 'delete', array('id' => $accountContact['id']));
+          CRM_Core_Session::setStatus(ts('You have deleted a contact that has been synced to your accounts system. The sync tracking record has been deleted. Resolution is unclear'));
 
+        }
       }
-    }
-    catch(Exception $e) {
-      //doesn't exist - move along, nothing to see here
+      catch(Exception $e) {
+        //doesn't exist - move along, nothing to see here
+      }
     }
   }
 }
@@ -494,21 +496,23 @@ function _accountsync_handle_contact_deletion($op, $entity, $id, &$params) {
  */
 function _accountsync_handle_contribution_deletion($op, $objectName, $id, &$params) {
   if (($op == 'delete') && ($objectName == 'Contribution')) {
-    try {
-      $accountInvoice = civicrm_api3('AccountInvoice', 'getsingle', array(
-        'contribution_id' => $id,
-        'plugin' => 'xero')
-      );
-      if (empty($accountInvoice['accounts_invoice_id'])) {
-        civicrm_api3('AccountInvoice', 'delete', array('id' => $accountInvoice['id']));
+    foreach(_accountsync_get_enabled_plugins() as $plugin) {
+      try {
+        $accountInvoice = civicrm_api3('AccountInvoice', 'getsingle', array(
+          'contribution_id' => $id,
+          'plugin' => $plugin)
+        );
+        if (empty($accountInvoice['accounts_invoice_id'])) {
+          civicrm_api3('AccountInvoice', 'delete', array('id' => $accountInvoice['id']));
+        }
+        else {
+          //here we need to create a way to void
+          CRM_Core_Session::setStatus(ts('You have deleted an invoice that has been synced to your accounts system. You will need to remove it from your accounting package'));
+        }
       }
-      else {
-        //here we need to create a way to void
-        CRM_Core_Session::setStatus(ts('You have deleted an invoice that has been synced to your accounts system. You will need to remove it from your accounting package'));
+      catch (Exception $e) {
+        //doesn't exist - move along, nothing to see here
       }
-    }
-    catch (Exception $e) {
-      //doesn't exist - move along, nothing to see here
     }
   }
 }
@@ -606,29 +610,33 @@ function accountsync_civicrm_angularModules(&$angularModules) {
  */
 function _accountsync_create_account_invoice($contributionID, $createNew, $connector_id) {
   $accountInvoice = array('contribution_id' => $contributionID, 'accounts_needs_update' => 1);
-  if ($connector_id) {
-    $accountInvoice['connector_id'] = $connector_id;
-  }
-  try {
-    $accountInvoice['id'] = civicrm_api3('AccountInvoice', 'getvalue', array(
-      'plugin' => 'xero',
-      'return' => 'id',
-      'contribution_id' => $contributionID,
-      'connector_id' => $connector_id,
-      ));
-  }
-  catch (CiviCRM_API3_Exception $e) {
-    // new contact
-    if (!$createNew) {
-      return;
+  foreach(_accountsync_get_enabled_plugins() as $plugin) {
+    unset($accountInvoice['id']); // Ensure id is not set in case of multiple plugins
+
+    if ($connector_id) {
+      $accountInvoice['connector_id'] = $connector_id;
     }
-  }
-  $accountInvoice['plugin'] = 'xero';
-  try {
-    civicrm_api3('AccountInvoice', 'create', $accountInvoice);
-  }
-  catch (CiviCRM_API3_Exception $e) {
-    // Unknown failure.
+    try {
+      $accountInvoice['id'] = civicrm_api3('AccountInvoice', 'getvalue', array(
+        'plugin' => $plugin,
+        'return' => 'id',
+        'contribution_id' => $contributionID,
+        'connector_id' => $connector_id,
+      ));
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // new contact
+      if (!$createNew) {
+        continue;
+      }
+    }
+    $accountInvoice['plugin'] = $plugin;
+    try {
+      civicrm_api3('AccountInvoice', 'create', $accountInvoice);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // Unknown failure.
+    }
   }
 }
 
@@ -646,15 +654,17 @@ function _accountsync_create_account_invoice($contributionID, $createNew, $conne
  */
 function accountsync_civicrm_merge($type, $data, $new_id = NULL, $old_id = NULL, $tables = NULL) {
   if (!empty($new_id) && !empty($old_id) && $type == 'sqls') {
-    try {
-      //@todo - this will only move old contact ref to the new one - if both have xero accounts
-      // then it will fail
-      $accountContact = civicrm_api3('account_contact', 'getsingle', array('plugin' => 'xero', 'contact_id' => $old_id));
-      $accountContact['contact_id'] = $new_id;
-      civicrm_api3('account_contact', 'create', $accountContact);
-    }
-    catch (Exception $e) {
-      //nothing to do here
+    foreach(_accountsync_get_enabled_plugins() as $plugin) {
+      try {
+        //@todo - this will only move old contact ref to the new one - if both have xero accounts
+        // then it will fail
+        $accountContact = civicrm_api3('account_contact', 'getsingle', array('plugin' => $plugin, 'contact_id' => $old_id));
+        $accountContact['contact_id'] = $new_id;
+        civicrm_api3('account_contact', 'create', $accountContact);
+      }
+      catch (Exception $e) {
+        //nothing to do here
+      }
     }
   }
 }


### PR DESCRIPTION
As part of a project to support a different accounting package we've implemented a system using CiviCRM's hook utilities that allows you to specify the plugin(s) available to accountsync.  Currently it lets you use multiple at the same time, which may need to be addressed.
