### PR TITLE
Add preference to allow override of receipting options for completed contributions

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -167,11 +167,11 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     $dao = CRM_Core_DAO::executeQuery($sql);
 
     // Get send receipt override
-    $result = civicrm_api3('Setting', 'get', array(
-        'sequential' => 1,
-        'return' => "account_sync_send_receipt",
+    $result = civicrm_api3('Setting', 'getvalue', array(
+        'domain_id' => CRM_Core_Config::domainID(),
+        'name' => 'account_sync_send_receipt',
       ));
-    switch ($result['values'][0]['account_sync_send_receipt']) {
+    switch ($result) {
       case 'send':
         $send_receipt = 1;
         break;

--- a/settings/AccountSync.setting.php
+++ b/settings/AccountSync.setting.php
@@ -106,4 +106,24 @@ return array(
       'formatType' => 'activityDateTime',
     )
   ),
+  'account_sync_send_receipt' => array(
+    'group_name' => 'Account Sync',
+    'group' => 'accountsync',
+    'name' => 'account_sync_send_receipt',
+    'type' => 'Array',
+    'add' => '4.4',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => array('no_override'),
+    'title' => 'Send receipts for Contributions',
+    'description' => '',
+    'help_text' => 'Set \'Send receipt?\' option for all Contributions synced.',
+    'html_type' => 'Select',
+    'quick_form_type' => 'Element',
+    'html_attributes' => array(
+      'no_override' => 'No override',
+      'send' => 'Send',
+      'do_not_send' => 'Do not send',
+    ),
+  ),
  );


### PR DESCRIPTION
See issue at https://github.com/eileenmcnaughton/nz.co.fuzion.accountsync/issues/22