### PR TITLE
Avoid invalid status to create invoices

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -169,8 +169,7 @@ function accountsync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
       if (in_array($objectRef->payment_processor, $skipInvoiceEntities)) {
         return;
       }
-      $pushEnabledStatuses = Civi::settings()->get('xero_push_contribution_status');
-
+      $pushEnabledStatuses = Civi::settings()->get('account_sync_push_contribution_status');
       //Don't create account invoice for zero contribution.
       //Skip contribution with status not enabled in xero settings.
       $contribution = civicrm_api3('Contribution', 'getsingle', array(

--- a/accountsync.php
+++ b/accountsync.php
@@ -169,18 +169,15 @@ function accountsync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
       if (in_array($objectRef->payment_processor, $skipInvoiceEntities)) {
         return;
       }
-      //Don't create account invoice for zero contribution.
-      // On update the property may not exist, in which case we should skip the check.
-      if (property_exists($objectRef, 'total_amount') && empty(floatval($objectRef->total_amount))) {
-        continue;
-      }
       $pushEnabledStatuses = Civi::settings()->get('xero_push_contribution_status');
-      $status = civicrm_api3('Contribution', 'getvalue', array(
-        'id' => $contribution_id,
-        'return' => "contribution_status_id",
-      ));
+
+      //Don't create account invoice for zero contribution.
       //Skip contribution with status not enabled in xero settings.
-      if (!in_array($status, $pushEnabledStatuses)) {
+      $contribution = civicrm_api3('Contribution', 'getsingle', array(
+        'id' => $contribution_id,
+        'return' => array("total_amount", "contribution_status_id"),
+      ));
+      if (empty(floatval($contribution['total_amount'])) || !in_array($contribution['contribution_status_id'], $pushEnabledStatuses)) {
         continue;
       }
 

--- a/accountsync.php
+++ b/accountsync.php
@@ -174,6 +174,16 @@ function accountsync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
       if (property_exists($objectRef, 'total_amount') && empty(floatval($objectRef->total_amount))) {
         continue;
       }
+      $pushEnabledStatuses = Civi::settings()->get('xero_push_contribution_status');
+      $status = civicrm_api3('Contribution', 'getvalue', array(
+        'id' => $contribution_id,
+        'return' => "contribution_status_id",
+      ));
+      //Skip contribution with status not enabled in xero settings.
+      if (!in_array($status, $pushEnabledStatuses)) {
+        continue;
+      }
+
       // we won't do updates as the invoices get 'locked' in the accounts system
       _accountsync_create_account_invoice($contribution_id, TRUE, $connector_id);
     }

--- a/settings/AccountSync.setting.php
+++ b/settings/AccountSync.setting.php
@@ -10,6 +10,10 @@ $processors = array();
 foreach ($results['values'] as $processor => $details) {
   $processors[$processor] = $details['name'];
 }
+$status = civicrm_api3('Contribution', 'getoptions', array(
+  'field' => 'contribution_status_id',
+));
+$defaultContributionStatus = array_keys(array_intersect($status['values'], array('Completed', 'Pending')));
 
 return array(
   'account_sync_queue_contacts' => array(
@@ -125,5 +129,27 @@ return array(
       'send' => 'Send',
       'do_not_send' => 'Do not send',
     ),
+  ),
+  'account_sync_push_contribution_status' => array(
+    'group_name' => 'Account Sync',
+    'group' => 'accountsync',
+    'name' => 'account_sync_push_contribution_status',
+    'type' => 'Array',
+    'add' => '4.7',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'default' => $defaultContributionStatus,
+    'description' => 'Select contribution status that can be pushed to Invoice table.',
+    'title' =>  'Push Contribution Status',
+    'help_text' => '',
+    'html_type' => 'Select',
+    'html_attributes' => array(
+      'multiple' => 1,
+      'class' => 'crm-select2',
+    ),
+    'pseudoconstant' => array(
+      'optionGroupName' => 'contribution_status',
+    ),
+    'quick_form_type' => 'Select',
   ),
  );


### PR DESCRIPTION
We found $objectRef containing total amount but not its value while updating the contribution. As, we already fetch status from api, this changes check `total_amount` with the same.