### PR TITLE
CIVIXERO-6: Prevent adding contact new record into civicrm_account_contact table for soft deleted contacts.

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -605,6 +605,21 @@ function _accountsync_create_account_contact($contactID, $createNew, $connector_
     // Do not rollback on fail.
     'is_transactional' => FALSE,
   );
+
+  try {
+    $contact = civicrm_api3("contact", "getsingle", array(
+        "id"     => $contactID,
+        "return" => array("id", "is_deleted"),
+    ));
+    if ($contact["contact_is_deleted"]) {
+        // Contact is deleted, Skip the sync.
+        return;
+    }
+  } catch(CiviCRM_API3_Exception $e) {
+    // Contact not found, Skip the sync.
+    return;
+  }
+
   foreach (_accountsync_get_enabled_plugins() as $plugin) {
     $accountContact['plugin'] = $plugin;
     $accountContact['connector_id'] = $connector_id;


### PR DESCRIPTION
**Steps to reproduce the issue**
1. Create a contact in CiviCRM, which adds an entry into civicrm_account_contact table. 
2. Delete this contact before is is synced with Xero.
3. Extension deletes the previous entry and adds a new one into the table. 
4. Now when we run a schedule job it syncs the deleted contact into Xero.

**Expected behaviour**
When contact is getting deleted and extension should not add new entry into the table.

**Solution**
Check if the contact is deleted or not, if it is deleted skip the Contact sync in __accountsync_create_account_contact_ hook.