### PR TITLE
Fix Undefined index: contact_is_deleted in _accountsync_create_accoun…

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -609,7 +609,7 @@ function _accountsync_create_account_contact($contactID, $createNew, $connector_
   try {
     $contact = civicrm_api3("contact", "getsingle", array(
         "id"     => $contactID,
-        "return" => array("id", "is_deleted"),
+        "return" => array("id", "contact_is_deleted"),
     ));
     if ($contact["contact_is_deleted"]) {
         // Contact is deleted, Skip the sync.


### PR DESCRIPTION
…t_contact

Modified it to the correct key to avoid notice error in logs. `is_deleted` does not return the key `contact_is_deleted` in the result array. Also checked on 4.6 version so don't think it is a regression. Do we need to support `is_deleted` return value or the one specified here is fine?