### PR TITLE
CIVICRM-870: Skip contrition to get added in account_invoice table if it's a test contribution.

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -173,7 +173,7 @@ function accountsync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
       //Don't create account invoice for zero contribution.
       //Skip contribution with status not enabled in settings.
       $contriValues = array();
-      $returnValues = array('contribution_status_id', 'total_amount');
+      $returnValues = array('contribution_status_id', 'total_amount', 'is_test');
       foreach ($returnValues as $key => $val) {
         if (!empty($objectRef->$val)) {
           $contriValues[$val] = $objectRef->$val;
@@ -188,7 +188,7 @@ function accountsync_civicrm_post($op, $objectName, $objectId, &$objectRef) {
         ));
         $contriValues = array_merge($contriValues, $apiValues);
       }
-      if (empty(floatval($contriValues['total_amount'])) || !in_array($contriValues['contribution_status_id'], $pushEnabledStatuses)) {
+      if ($contriValues['is_test'] || empty(floatval($contriValues['total_amount'])) || !in_array($contriValues['contribution_status_id'], $pushEnabledStatuses)) {
         continue;
       }
       // we won't do updates as the invoices get 'locked' in the accounts system


### PR DESCRIPTION
## Steps to reproduce

1. Create a contribution page with Pay Later option enabled.
2. Contribution should have the financial type of Member Dues
3. Submit new contribution via Test-Drive link

Notice the contribution is added in account_invoice table which syncs the data with any of the available plugins.

## Solution

Added **is_test** to get returned and checking it's value along with **total_amount**. If **is_test** is true we skip the particular Contribution.