### PR TITLE
CIVIXERO-15: Cancel contributions regardless of it's status.

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -201,7 +201,6 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     $sql = "SELECT  cas.contribution_id
       FROM civicrm_account_invoice cas
       LEFT JOIN civicrm_contribution  civi ON cas.contribution_id = civi.id
-      WHERE civi.contribution_status_id =2
       AND accounts_status_id =3
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);


### PR DESCRIPTION
## Overview

CiviCRM contribution status is not changed to cancelled when the linked Xero invoice status is changed to voided.

## Steps to reproduce:

1. Create a contribution in CiviCRM
2. Mark the contribution as completed in CiviCRM
3. Sync the contribution with Xero
4. Change the status of the invoice in Xero to voided
5. Sync the change to CiviCRM
6. Check the status of the contribution, it is still completed

This is because AccountInvoice.update_contribution API Update contribution status to cancelled for only pending contributions. 