### PR TITLE
CiviXero Invoice push fails if contribution has no payment_instrument_id

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -98,8 +98,8 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       $contribution['payment_instrument_id'] = array_search($contribution['payment_instrument'], $paymentInstruments['values']);
     }
 
-    $contribution['payment_instrument_financial_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($contribution['payment_instrument_id']);
     try {
+      $contribution['payment_instrument_financial_account_id'] = CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount($contribution['payment_instrument_id']);
       $contribution['payment_instrument_accounting_code'] = civicrm_api3('financial_account', 'getvalue', array(
         'id' => $contribution['payment_instrument_financial_account_id'],
         'return' => 'accounting_code',


### PR DESCRIPTION
See [CiviXero issue 45](https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/issues/45) for an explanation.

This change moves the call to CRM_Financial_BAO_FinancialTypeAccount::getInstrumentFinancialAccount() into the try/catch block which surrounds the following code, so if the payment_instrument_id is unset the ensuing exception is handled locally rather than stopping CiviXero pushing this invoice to Xero.

This change has been tested for the following 2 cases:

1. a Pending contribution has no payment instrument
2. a recurring PayPal Standard contribution has no payment instrument for the second and subsequent contributions (this is probably a bug with that payment processor)

In both these cases the CiviXero push invoice job successfully pushes the invoices to Xero.

