### PR TITLE
Fixed completeContributionFromAccountsStatus to continue execution even if one contribution fails.

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -106,7 +106,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       ));
     }
     catch(Exception $e) {
-      ;
+
     }
 
     return array($contribution['id'] => $contribution);
@@ -157,7 +157,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
    */
   public static function completeContributionFromAccountsStatus() {
     $sql = "
-      SELECT contribution_id, receive_date
+      SELECT cas.id civicrm_account_invoice_id, contribution_id, receive_date
       FROM civicrm_account_invoice cas
       LEFT JOIN civicrm_contribution  civi ON cas.contribution_id = civi.id
       WHERE civi.contribution_status_id =2
@@ -174,9 +174,11 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       case 'send':
         $send_receipt = 1;
         break;
+
       case 'do_not_send':
         $send_receipt = 0;
         break;
+
       default:
         $send_receipt = NULL;
         break;
@@ -192,7 +194,11 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       }
       catch (CiviCRM_API3_Exception $e) {
         // CiviCRM failed to complete the contribution.
-        // TODO: Need to log error somewhere so Admin know contribution completed transaction has failed.
+        $error = 'Contribution:completetransaction API failed, ' . $e->getMessage();
+        civicrm_api3('AccountInvoice', 'create', array(
+          'id'         => $dao->civicrm_account_invoice_id,
+          'error_data' => json_encode([$error]),
+        ));
       }
     }
   }

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -187,7 +187,13 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       if (is_numeric($isSendReceipt)) {
         $params['is_email_receipt'] = $send_receipt;
       }
-      civicrm_api3('contribution', 'completetransaction', $params);
+      try {
+        civicrm_api3('contribution', 'completetransaction', $params);
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        // CiviCRM failed to complete the contribution.
+        // TODO: Need to log error somewhere so Admin know contribution completed transaction has failed.
+      }
     }
   }
 


### PR DESCRIPTION
Overview
------------
Let's assume we've 10 contributions in the system and their statues needs to updated because they are paid in any Invoicing software (e.g. Xero) 

First contribution picked by  **completeContributionFromAccountsStatus** function has some issues and **completetransaction**  API throws an exception. This exception is not handled in the function because of that rest of the contributions are skipped. 

Expected Behaviour
 ------------
If there is some issue with the contribution, We should log the error in DB and skip particular contribution and continue with rest of the contributions.

Solution
 ------------
Implemented a try/catch block to catch the exception thrown by **completetransaction** api and the error is stored into the DB for admin to review. 

_Agileware Ref: DCA-71_