### PR TITLE
CIVIXERO-33: Fix variable check to override sending receipt.

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -187,7 +187,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
 
     while ($dao->fetch()) {
       $params = array('id' => $dao->contribution_id, 'receive_date' => $dao->receive_date);
-      if (is_numeric($isSendReceipt)) {
+      if (is_numeric($send_receipt)) {
         $params['is_email_receipt'] = $send_receipt;
       }
       try {


### PR DESCRIPTION
This one's apparently been broken for over 2 years, but only recently came up for one of our clients.

The code to override whether CiviCRM should send a receipt is checking the wrong variable – `$isSendReceipt` is not a number.  Here is a fix.