### PR TITLE
With CiviXero, 'Queue Sync to Xero' has NULL connector_id

### DIFF
--- a/CRM/Accountsync/BAO/AccountContact.php
+++ b/CRM/Accountsync/BAO/AccountContact.php
@@ -13,6 +13,7 @@ class CRM_Accountsync_BAO_AccountContact extends CRM_Accountsync_DAO_AccountCont
     $className = 'CRM_Accountsync_DAO_AccountContact';
     $entityName = 'AccountContact';
     $hook = empty($params['id']) ? 'create' : 'edit';
+    $params['connector_id'] = $params['connector_id'] ?? 0;
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
     $instance = new $className();


### PR DESCRIPTION
With CiviXero, when I click 'Queue Sync to Xero' an entry is created in the Accounts Contact table with connector_id NULL. The Contact Push job ignores this. When creating and Accounts Contact set connector_id to zero if none is supplied.