### PR TITLE
Fix cancel contribution api to not update contact entity on every api…

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -214,7 +214,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     $sql = "SELECT  cas.contribution_id
       FROM civicrm_account_invoice cas
       LEFT JOIN civicrm_contribution  civi ON cas.contribution_id = civi.id
-      WHERE accounts_status_id =3
+      WHERE accounts_status_id =3 AND contribution_status_id != 3
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
… call

![image](https://user-images.githubusercontent.com/5929648/96674141-b3059e00-1385-11eb-99b6-16c5b8a9d82b.png)

Problem - The above API triggers contribution create even if the payment is already canceled. This results in account_needs_update = 1 in the account_contact table. So if there are more than 100 canceled invoices, this results in 100 contact updates being tried on the next contact push job.

The latter is capable to only push 25 contact entities in single job execution. So the count to push is never completed and eventually results in throttling the xero api limit.