### PR TITLE
Improve sync / matching of contacts.

### DIFF
--- a/ang/accountsync/EditCtrl.html
+++ b/ang/accountsync/EditCtrl.html
@@ -7,8 +7,9 @@
 
       <tr ng-repeat="accountContact in accountContacts" ng-class-even="'crm-entity even-row even'" ng-class-odd="'crm-entity odd-row odd'">
         <td>
-          <p ng-show="accountContact.accounts_display_name">{{ ts('%1', {1: accountContact.accounts_display_name}) }}</p>
-          <p ng-show="accountContact.accounts_data.civicrm_formatted.email">({{ ts('%1', {1: accountContact.accounts_data.civicrm_formatted.email}) }})</p>
+          <p ng-show="accountContact.accounts_display_name">{{ accountContact.accounts_display_name }}</p>
+          <p ng-show="accountContact.accounts_data.civicrm_formatted.email">({{ accountContact.accounts_data.civicrm_formatted.email }})</p>
+          <p ng-show="accountContact.accounts_contact_id">{{ accountContact.accounts_contact_id }}</p>
           <p ng-show="!accountContact.accounts_display_name">{{ ts('Name not provided.') }}</p>
         </td>
         <td>

--- a/ang/accountsync/EditCtrl.js
+++ b/ang/accountsync/EditCtrl.js
@@ -122,7 +122,7 @@
         case 'link_contact':
           success = crmStatus(
             {start: ts('Saving...'), success: ts('Saved')},
-            crmApi('AccountContact', 'create', {
+            crmApi('AccountContact', 'link', {
               'id' : accountContact.id,
               'contact_id' : accountContact.suggested_contact_id,
               'accounts_needs_update' : 1,

--- a/api/v3/AccountContact.php
+++ b/api/v3/AccountContact.php
@@ -35,7 +35,7 @@ function civicrm_api3_account_contact_link($params) {
       ->execute();
   }
   else {
-    throw new CRM_Core_Exception('Contact ID is already matched to an AccountContact ID');
+    throw new CRM_Core_Exception('Contact ID (' . $params['contact_id'] . ') is already matched to an AccountContact ID: ' . $existingEntry['accounts_contact_id']);
   }
   return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountContact', $params);
 }

--- a/api/v3/AccountContact.php
+++ b/api/v3/AccountContact.php
@@ -13,6 +13,34 @@ function civicrm_api3_account_contact_create($params) {
 }
 
 /**
+ * Synchronise contacts does not like it if there is an existing entry in the account_contact table that is not linked to an accounts_contact_id
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \CRM_Core_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
+ */
+function civicrm_api3_account_contact_link($params) {
+  if (empty($params['id']) || empty($params['contact_id'])) {
+    throw new CRM_Core_Exception('Missing mandatory parameters');
+  }
+  $existingEntry = \Civi\Api4\AccountContact::get(FALSE)
+    ->addWhere('contact_id', '=', $params['contact_id'])
+    ->execute()
+    ->first();
+  if (empty($existingEntry['accounts_contact_id'])) {
+    \Civi\Api4\AccountContact::delete(FALSE)
+      ->addWhere('id', '=', $existingEntry['id'])
+      ->execute();
+  }
+  else {
+    throw new CRM_Core_Exception('Contact ID is already matched to an AccountContact ID');
+  }
+  return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountContact', $params);
+}
+
+/**
  * AccountContact.delete API
  *
  * @param array $params


### PR DESCRIPTION
Builds on #59.

- Show 25 contacts (instead of 10) on contact match screen and tidy up. Ideally we'd replace this matching page with one that uses a pager so you're not forced to reconcile the ones it displays first but this is a quick fix that helps a bit.
- Improve getsuggestions API to reduce false positives/bugs etc. and add "AccountContact.savesuggestions" API which can bulk accept all "link_contacts" suggestions.
 - Handle existing contact_id in account_contact table when matching - previously it would crash with "duplicate db error" because there is one record with only accountcontact and another record with only civicrm contact. 
- Show accounts_contact_id in contact matching (just makes it a bit easier to debug / see what is going on).