### PR TITLE
Allow to not create a new AccountInvoice entry (a bit hacky)

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -44,6 +44,15 @@ function accountsync_civicrm_post(string $op, string $objectName, $objectId, &$o
     return;
   }
 
+  // See https://github.com/eileenmcnaughton/nz.co.fuzion.accountsync/pull/62
+  // If an accounts provider (eg. Xero) creates a Contribution in CiviCRM this post hook will always fire
+  //   which will cause it to create a new AccountsInvoice record before the code has chance to update an existing AccountsInvoice record
+  //   if one already exists but does not yet contain a CiviCRM contribution ID.
+  // By setting this flag to FALSE we can prevent this hook from triggering the AccountsInvoice create action.
+  if (isset(\Civi::$statics['data.accountsync.createcontribution']['createnew']) && (\Civi::$statics['data.accountsync.createcontribution']['createnew'] === FALSE)) {
+    return;
+  }
+
   $connectors = _accountsync_get_connectors();
   $objectName = _accountsync_map_object_name_to_entity($objectName);
 


### PR DESCRIPTION
I've implemented a function to "Create Invoice in CiviCRM" if it does not exist on Xero Invoice Pull in my fork of civixero. But there is a problem because this hook *always* fires and creates an AccountInvoice entry as soon as we call "Contribution::Create" and then we end up with two records in AccountInvoice - one containing CiviCRM contact ID and one containing Xero accounts_invoice_id.

Changing the below parameter stops the new record being created and the existing one updates automatically to map contribution_id to accounts_invoice_id.

@eileenmcnaughton Any thoughts on a better way to do this?
(see https://github.com/mjwconsult/nz.co.fuzion.civixero/commit/f1db1a516b48deb99d647809d93a92d7c8107609#diff-ae8087fabc2278332d47c7a8c20ef96d456517ae2f3ecde0f4a3c8e8ac10139aR164)