### PR TITLE
Add contactID to contact errors. Add/rename actions

### DIFF
--- a/Civi/Hooks/SearchKitTasks.php
+++ b/Civi/Hooks/SearchKitTasks.php
@@ -25,23 +25,33 @@ class SearchKitTasks {
         case 'AccountInvoice_Synchronization_Errors_Display':
           foreach (['AccountContact', 'AccountInvoice'] as $entity) {
             $tasks[$entity]['queue'] = [
-              'title' => E::ts('Re-queue %1', [1 => 'record']),
+              'title' => E::ts('Retry sync'),
               'apiBatch' => [
                 'action' => 'update',
-                'params' => ['values' => ['accounts_needs_update' => TRUE, 'error_data' => '']],
-                'runMsg' => E::ts('Queueing synchronization ...'),
-                'successMsg' => E::ts('Successfully re-queued %1 record.'),
-                'errorMsg' => E::ts('An error occurred while attempting to queue the record.'),
+                'params' => ['values' => ['accounts_needs_update' => TRUE, 'error_data' => '', 'is_error_resolved' => TRUE]],
+                'runMsg' => E::ts('Processing ...'),
+                'successMsg' => E::ts('Successfully marked %1 records to retry next time the sync job runs.'),
+                'errorMsg' => E::ts('An error occurred while attempting to mark %1 records for retry.'),
               ],
             ];
             $tasks[$entity]['dismiss'] = [
-              'title' => E::ts('Dismiss error %1', [1 => 'record']),
+              'title' => E::ts('Mark as resolved'),
               'apiBatch' => [
                 'action' => 'update',
                 'params' => ['values' => ['is_error_resolved' => TRUE]],
-                'runMsg' => E::ts('Dismissing error ...'),
-                'successMsg' => E::ts('Successfully dismissed error for %1 record.'),
-                'errorMsg' => E::ts('An error occurred while attempting to dismiss the error.'),
+                'runMsg' => E::ts('Processing ...'),
+                'successMsg' => E::ts('Successfully marked %1 records as resolved.'),
+                'errorMsg' => E::ts('An error occurred while marking errors as resolved.'),
+              ],
+            ];
+            $tasks[$entity]['donotsync'] = [
+              'title' => E::ts('Do not sync'),
+              'apiBatch' => [
+                'action' => 'update',
+                'params' => ['values' => ['do_not_sync' => TRUE, 'is_error_resolved' => TRUE]],
+                'runMsg' => E::ts('Processing ...'),
+                'successMsg' => E::ts('Successfully marked %1 records as "Do not Sync".'),
+                'errorMsg' => E::ts('An error occurred while marking errors as "Do not Sync".'),
               ],
             ];
           }

--- a/managed/contact_errors.mgd.php
+++ b/managed/contact_errors.mgd.php
@@ -20,11 +20,14 @@ return [
           'select' => [
             'id',
             'contact_id.display_name',
+            'contact_id',
             'accounts_contact_id',
             'error_data',
             'last_sync_date',
           ],
-          'orderBy' => ['id DESC'],
+          'orderBy' => [
+            'id DESC',
+          ],
           'where' => [
             [
               'is_error_resolved',
@@ -42,7 +45,7 @@ return [
     ],
   ],
   [
-    'name' => 'SavedSearch_AccountContact_Synchronization_Errors_SearchDisplay_AccountContact_Synchronization_Errors_Table_1',
+    'name' => 'SavedSearch_AccountContact_Synchronization_Errors_SearchDisplay_AccountContact_Synchronization_Errors_Display',
     'entity' => 'SearchDisplay',
     'cleanup' => 'unused',
     'update' => 'unmodified',
@@ -80,9 +83,24 @@ return [
             ],
             [
               'type' => 'field',
+              'key' => 'contact_id',
+              'dataType' => 'Integer',
+              'label' => 'CiviCRM Contact ID',
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '',
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => 'contact_id',
+                'target' => '_blank',
+              ],
+              'title' => 'View CiviCRM Contact',
+            ],
+            [
+              'type' => 'field',
               'key' => 'accounts_contact_id',
               'dataType' => 'String',
-              'label' => 'accounts_contact_id',
+              'label' => 'Accounts Contact ID',
               'sortable' => TRUE,
             ],
             [
@@ -100,6 +118,7 @@ return [
               'sortable' => TRUE,
             ],
           ],
+          'headerCount' => TRUE,
         ],
         'acl_bypass' => FALSE,
       ],


### PR DESCRIPTION
* Add "Contact ID" column to contact errors display.
* Rename / add search tasks:
  * Re-queue -> retry sync (and add "is_error_resolved=true" - otherwise you can't tell that you've marked them for retry).
  * Dismiss error -> mark as resolved
  * Do not sync: New one to mark that you don't want to sync.

Both "re-queue" and "dismiss error" confused me and my clients and they also didn't quite work properly!