### PR TITLE
Switch to Payment.create, use pseudoconstants, simplify receipt handling

### DIFF
--- a/api/v3/AccountInvoice.php
+++ b/api/v3/AccountInvoice.php
@@ -85,7 +85,7 @@ function civicrm_api3_account_invoice_getderived($params) {
  */
 function civicrm_api3_account_invoice_update_contribution($params) {
   if ($params['accounts_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'completed')) {
-    CRM_Accountsync_BAO_AccountInvoice::completeContributionFromAccountsStatus($params);
+    CRM_Accountsync_BAO_AccountInvoice::completeContributionFromAccountsStatus();
   }
   elseif ($params['accounts_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Accountsync_BAO_AccountInvoice', 'accounts_status_id', 'cancelled')) {
     CRM_Accountsync_BAO_AccountInvoice::cancelContributionFromAccountsStatus($params);


### PR DESCRIPTION
I've been having problems on one site where invoices appear to be being sent twice. According to the code it was set to "no_override" in accountsync so it should be doing whatever it's set to. But it's definitely sending an invoice and not a receipt.
First step to troubleshooting is changing from Contribution.completetransaction to Payment.create which is what this PR does.