### PR TITLE
Improvements / fixes

### DIFF
--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -326,6 +326,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
    */
   public static function getAccountStatuses(): array {
     return [
+      ['id' => 0, 'name' => 'unknown', 'label' => E::ts('Unknown')],
       ['id' => 1, 'name' => 'completed', 'label' => E::ts('Completed')],
       ['id' => 2, 'name' => 'pending', 'label' => E::ts('Pending')],
       ['id' => 3, 'name' => 'cancelled', 'label' => E::ts('Cancelled')],

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -54,6 +54,15 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
           ],
         ],
       ], $params));
+      $accountContact = \Civi\Api4\AccountContact::get(FALSE)
+        ->addSelect('accounts_contact_id')
+        ->addWhere('contact_id', '=', $contribution['contact_id'])
+        ->execute()
+        ->first();
+      if (!empty($accountContact['accounts_contact_id'])) {
+        $contribution['accounts_contact_id'] = $accountContact['accounts_contact_id'];
+      }
+
       // There is a chaining bug on line item because chaining passes contribution_id along as entity_id.
       // CRM-16522.
       $contribution['api.line_item.get'] = civicrm_api3('line_item', 'get', [

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -98,6 +98,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     }
     catch (Exception $e) {
       // probably shouldn't catch & let calling class catch
+      \Civi::log()->error('AccountInvoice.Getderived: ' . $e->getMessage());
     }
 
     // In 4.6 this might be more reliable as Monish did some tidy up on BAO_Search stuff.
@@ -115,7 +116,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       ]);
     }
     catch (Exception $e) {
-
+      \Civi::log()->error('AccountInvoice.Getderived: ' . $e->getMessage());
     }
 
     return [$contribution['id'] => $contribution];

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -189,6 +189,8 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     $dao = CRM_Core_DAO::executeQuery($sql, $queryParams);
 
     $paymentParams = [];
+    // We are receiving directly from contribution table so it will be well formatted.
+    $paymentParams['skipCleanMoney'] = TRUE;
     // Get send receipt override
     switch (Civi::settings()->get('account_sync_send_receipt')) {
       case 'send':

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -84,7 +84,6 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
       foreach ($contribution['line_items'] as &$lineItem) {
         $lineItem['accounting_code'] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($lineItem['financial_type_id']);
         $lineItem['accounts_contact_id'] = self::getAccountsContact($lineItem['financial_type_id']);
-        $contributionAccountsContactIDs[$lineItem['accounts_contact_id']] = TRUE;
         if (!isset($lineItem['contact_id'])) {
           //this would have been set for a secondary participant above so we are ensuring primary ones have it
           // for conformity & ease downstream
@@ -96,9 +95,6 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
           $lineItem['display_name'] = $contribution['display_name'];
         }
       }
-      //@todo move the getAccountingCode to a fn that caches it
-      $contribution['accounting_code'] = CRM_Financial_BAO_FinancialAccount::getAccountingCode($contribution['financial_type_id']);
-      $contribution['accounts_contact_id'] = array_keys($contributionAccountsContactIDs);
     }
     catch (Exception $e) {
       // probably shouldn't catch & let calling class catch

--- a/accountsync.php
+++ b/accountsync.php
@@ -247,7 +247,7 @@ function _accountsync_validate_for_connector($connector_id, $financial_type_id) 
  *   Connector ID if nz.co.fuzion.connectors is installed, else 0.
  *
  * @return array
- *   Entities that result in a contact being created when the are edited or created.
+ *   Entities that result in a contact being created when they are edited or created.
  *
  * @throws \CiviCRM_API3_Exception
  */

--- a/api/v3/AccountInvoice.php
+++ b/api/v3/AccountInvoice.php
@@ -73,6 +73,18 @@ function civicrm_api3_account_invoice_getderived($params) {
   return civicrm_api3_create_success(CRM_Accountsync_BAO_AccountInvoice::getDerived($params));
 }
 
+function _civicrm_api3_account_invoice_update_contribution_spec(&$spec) {
+  $spec['accounts_status_id'] = [
+    'type' => CRM_Utils_Type::T_INT,
+    'name' => 'accounts_status_id',
+    'title' => 'Accounts Status ID',
+    'description' => 'Status in accounts system (mapped to CiviCRM definition)',
+    'pseudoconstant' => [
+      'callback' => 'CRM_Accountsync_BAO_AccountInvoice::getAccountStatuses',
+    ],
+  ];
+}
+
 /**
  * AccountInvoice.create API.
  *
@@ -91,7 +103,7 @@ function civicrm_api3_account_invoice_update_contribution($params) {
     CRM_Accountsync_BAO_AccountInvoice::cancelContributionFromAccountsStatus($params);
   }
   else {
-    throw new Exception('Currently only complete/cancel is supported');
+    throw new Exception('Currently only completed/cancelled is supported');
   }
   return civicrm_api3_create_success();
 }


### PR DESCRIPTION
@eileenmcnaughton some straightfoward fixes/improvements pulled from my fork.

* Add spec to API3 AccountInvoice.update_contribution

* Performance: skipCleanMoney

* Add accounts_contact_id to getderived using contribution contact_id

* Remove unused code (that breaks getderived because financial_type_id is not returned by default in API3 contribution.get) - this was causing getderived to fail silently.

* Log exceptions in getderived - if getderived fails actually log something...

* Fix https://github.com/eileenmcnaughton/nz.co.fuzion.accountsync/issues/75 0 (unknown) is a valid accounts status for invoice - tested and confirmed that this is an appropriate fix.