### PR TITLE
Handle existing contact_id in account_contact table when matching

### DIFF
--- a/ang/accountsync/EditCtrl.js
+++ b/ang/accountsync/EditCtrl.js
@@ -122,7 +122,7 @@
         case 'link_contact':
           success = crmStatus(
             {start: ts('Saving...'), success: ts('Saved')},
-            crmApi('AccountContact', 'create', {
+            crmApi('AccountContact', 'link', {
               'id' : accountContact.id,
               'contact_id' : accountContact.suggested_contact_id,
               'accounts_needs_update' : 1,

--- a/api/v3/AccountContact.php
+++ b/api/v3/AccountContact.php
@@ -35,7 +35,7 @@ function civicrm_api3_account_contact_link($params) {
       ->execute();
   }
   else {
-    throw new CRM_Core_Exception('Contact ID is already matched to an AccountContact ID');
+    throw new CRM_Core_Exception('Contact ID (' . $params['contact_id'] . ') is already matched to an AccountContact ID: ' . $existingEntry['accounts_contact_id']);
   }
   return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountContact', $params);
 }

--- a/api/v3/AccountContact.php
+++ b/api/v3/AccountContact.php
@@ -13,6 +13,34 @@ function civicrm_api3_account_contact_create($params) {
 }
 
 /**
+ * Synchronise contacts does not like it if there is an existing entry in the account_contact table that is not linked to an accounts_contact_id
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \CRM_Core_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
+ */
+function civicrm_api3_account_contact_link($params) {
+  if (empty($params['id']) || empty($params['contact_id'])) {
+    throw new CRM_Core_Exception('Missing mandatory parameters');
+  }
+  $existingEntry = \Civi\Api4\AccountContact::get(FALSE)
+    ->addWhere('contact_id', '=', $params['contact_id'])
+    ->execute()
+    ->first();
+  if (empty($existingEntry['accounts_contact_id'])) {
+    \Civi\Api4\AccountContact::delete(FALSE)
+      ->addWhere('id', '=', $existingEntry['id'])
+      ->execute();
+  }
+  else {
+    throw new CRM_Core_Exception('Contact ID is already matched to an AccountContact ID');
+  }
+  return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountContact', $params);
+}
+
+/**
  * AccountContact.delete API
  *
  * @param array $params

--- a/tests/phpunit/api/v3/AccountContactTest.php
+++ b/tests/phpunit/api/v3/AccountContactTest.php
@@ -1,102 +1,153 @@
 <?php
-require_once 'CiviTest/CiviUnitTestCase.php';
+
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for AccountContact class
+ * FIXME - Add test description.
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
  */
-class api_v3_AccountContactTest extends CiviUnitTestCase {
+class AccountContactTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
-  protected $_individualID;
+  use Test\EntityTrait;
+  use Test\ContactTestTrait;
+  use Test\Api3TestTrait;
 
-  function setUp(): void {
-    // If your test manipulates any SQL tables, then you should truncate
-    // them to ensure a consisting starting point for all tests
-    // $this->quickCleanup(array('example_table_name'));
-    parent::setUp();
-    $this->_individualID = $this->individualCreate();
-  }
-
-  function tearDown(): void {
-    $this->quickCleanup([
-      'civicrm_account_contact',
-    ]);
-    parent::tearDown();
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
   }
 
   /**
    * Test that a contact is created
    */
-  function testCreate() {
+  public function testActions(): void {
     $createParams = [
-      'contact_id' => $this->_individualID,
+      'contact_id' => $this->individualCreate(),
       'accounts_display_name' => 'ballerina',
-    ];
-    $result = $this->callAPIAndDocument('AccountContact', 'create', $createParams, __FUNCTION__, __FILE__);
-    $this->getAndCheck($createParams, $result['id'], 'account_contact');
-  }
-
-  /**
-   * Test that a contact is created
-   */
-  function testGetValue() {
-    $createParams = [
-      'contact_id' => $this->_individualID,
-      'accounts_display_name' => 'ballerina',
-      'accounts_contact_id' => 'ac62bce6-47a3-4937-9299-69c39693993a',
-      'plugin' => 'xero',
     ];
     $result = $this->callAPISuccess('AccountContact', 'create', $createParams);
-    $getParams = [
-      'accounts_contact_id' => 'ac62bce6-47a3-4937-9299-69c39693993a',
-      'plugin' => 'xero',
-      'return' => 'id',
-    ];
-    $result = $this->callAPIAndDocument('AccountContact', 'getvalue', $getParams, __FUNCTION__, __FILE__);
-  }
-
-  /**
-   * Test saving & retrieval of Xero Date
-   */
-  function testGetDate() {
-    $xeroDate = '2014-01-01T22:05:42.557';
-    $createParams = [
-      'contact_id' => $this->_individualID,
-      'accounts_display_name' => 'ballerina',
-      'accounts_contact_id' => 'ac62bce6-47a3-4937-9299-69c39693993a',
-      'plugin' => 'xero',
-      'accounts_modified_date' => $xeroDate,
-    ];
-    $this->callAPISuccess('AccountContact', 'create', $createParams);
-    $result = $this->callAPISuccess('AccountContact', 'getsingle', []);
-    $this->assertEquals($result['accounts_modified_date'], '2014-01-01 22:05:42');
+    $created = $this->callAPISuccessGetSingle('AccountContact', ['id' => $result['id']]);
+    $this->assertEquals('ballerina', $created['accounts_display_name']);
+    $result = $this->callAPISuccess('AccountContact', 'create', $createParams + [
+      'id' => $result['id'],
+      'last_sync_date' => '2024-01-01',
+    ]);
+    $created = $this->callAPISuccessGetSingle('AccountContact', ['id' => $result['id']]);
+    $this->assertEquals('2024-01-01 00:00:00', $created['last_sync_date']);
+    $this->callAPISuccess('AccountContact', 'delete', ['id' => $result['id']]);
   }
 
   /**
    * Test that getfields returns what it would if core getfields worked
    */
-  function testGetFields() {
-    $result = $this->callAPIAndDocument('AccountContact', 'getfields', [], __FUNCTION__, __FILE__);
+  public function testGetFields(): void {
+    $result = $this->callAPISuccess('AccountContact', 'getfields');
     $expected = [
       'id' => [
         'name' => 'id',
         'type' => 1,
-        'required' => 1,
+        'required' => TRUE,
         'api.aliases' => [
           '0' => 'account_contact_id',
         ],
+        'title' => 'ID',
+        'description' => 'Unique AccountContact ID',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.id',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
       ],
 
       'contact_id' => [
         'name' => 'contact_id',
         'type' => 1,
         'FKClassName' => 'CRM_Contact_DAO_Contact',
+        'title' => 'Contact ID',
+        'description' => 'FK to Contact',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.contact_id',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'EntityRef',
+          'label' => 'CiviCRM Contact ID',
+          'size' => 6,
+          'maxlength' => 14,
+        ],
+        'add' => '4.4',
+        'is_core_field' => TRUE,
+        'FKApiName' => 'Contact',
       ],
 
       'accounts_contact_id' => [
         'name' => 'accounts_contact_id',
         'type' => 2,
         'maxlength' => 128,
-        'size' => 20,
+        'size' => 45,
+        'title' => 'Accounts Contact ID',
+        'description' => 'External Reference',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.accounts_contact_id',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'Text',
+          'maxlength' => 128,
+          'size' => 45,
+        ],
+        'add' => '4.4',
+        'is_core_field' => TRUE,
       ],
 
       'last_sync_date' => [
@@ -104,12 +155,43 @@ class api_v3_AccountContactTest extends CiviUnitTestCase {
         'type' => 256,
         'title' => 'Last Sync Date',
         'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+        'description' => 'When was the contact last synced.',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.last_sync_date',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' =>  TRUE,
       ],
 
       'accounts_modified_date' => [
         'name' => 'accounts_modified_date',
-        'type' => 4,
+        'type' => 256,
         'title' => 'Accounts Modified Date',
+        'description' => 'When was the invoice last Altered in the accounts system.',
+        'required' => FALSE,
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.accounts_modified_date',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
       ],
       'accounts_display_name' => [
         'name' => 'accounts_display_name',
@@ -117,14 +199,52 @@ class api_v3_AccountContactTest extends CiviUnitTestCase {
         'title' => 'Display Name',
         'maxlength' => 128,
         'size' => 45,
+        'description' => 'Name from Accounts Package',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.accounts_display_name',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'Text',
+          'maxlength' => 128,
+          'size' => 45,
+        ],
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
       ],
 
       'accounts_data' => [
         'name' => 'accounts_data',
-        'type' => 2,
+        'type' => 32,
         'title' => 'Account System Data',
-        'maxlength' => 128,
-        'size' => 45,
+        'description' => 'json array of data as returned from accounts system',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.accounts_data',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'Text',
+          'rows' => 2,
+          'cols' => 80,
+        ],
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
       ],
 
       'plugin' => [
@@ -133,6 +253,141 @@ class api_v3_AccountContactTest extends CiviUnitTestCase {
         'title' => 'Account Plugin',
         'maxlength' => 32,
         'size' => 20,
+        'description' => 'Name of plugin creating the account',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.plugin',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
+      ],
+      'error_data' => [
+        'name' => 'error_data',
+        'type' => 32,
+        'title' => 'Account Error Data',
+        'description' => 'json array of error data as returned from accounts system',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.error_data',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'Text',
+          'rows' => 2,
+          'cols' => 80,
+        ],
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
+      ],
+      'accounts_needs_update' => [
+        'name' => 'accounts_needs_update',
+        'type' => 16,
+        'title' => 'Accounts Needs Update',
+        'description' => 'Include in next push to accounts',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.accounts_needs_update',
+        'default' => '1',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'CheckBox',
+        ],
+        'add' => '4.4',
+        'is_core_field' => TRUE,
+      ],
+      'connector_id' => [
+        'name' => 'connector_id',
+        'type' => 1,
+        'title' => 'Connector ID',
+        'description' => 'ID of connector. Relevant to connect to more than one account of the same type',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.connector_id',
+        'default' => '0',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'Text',
+          'size' => 6,
+          'maxlength' => 14,
+        ],
+        'readonly' => TRUE,
+        'add' => '4.4',
+        'is_core_field' => TRUE,
+      ],
+      'do_not_sync' => [
+        'name' => 'do_not_sync',
+        'type' => 16,
+        'title' => 'Do Not Sync',
+        'description' => 'Do not sync this contact',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.do_not_sync',
+        'default' => '0',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'CheckBox',
+        ],
+        'add' => '4.6',
+        'is_core_field' => TRUE,
+      ],
+      'is_error_resolved' => [
+        'name' => 'is_error_resolved',
+        'type' => 16,
+        'title' => 'Error Resolved',
+        'description' => 'Filter out if resolved',
+        'usage' => [
+          'import' => FALSE,
+          'export' => FALSE,
+          'duplicate_matching' => FALSE,
+          'token' => FALSE,
+        ],
+        'where' => 'civicrm_account_contact.is_error_resolved',
+        'default' => '0',
+        'table_name' => 'civicrm_account_contact',
+        'entity' => 'AccountContact',
+        'bao' => 'CRM_Accountsync_DAO_AccountContact',
+        'localizable' => 0,
+        'html' => [
+          'type' => 'CheckBox',
+        ],
+        'add' => '5.56',
+        'is_core_field' => TRUE,
       ],
     ];
     $this->assertEquals($expected, $result['values']);

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -7,10 +7,11 @@ eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CRM_', __DIR__);
-$loader->add('Civi\\', __DIR__);
-$loader->add('api_', __DIR__);
-$loader->add('api\\', __DIR__);
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
 $loader->register();
 
 /**


### PR DESCRIPTION
one of @mattwire's commits - I'm curious as to whether I can get tests to run 

https://github.com/eileenmcnaughton/nz.co.fuzion.accountsync/pull/60/commits/9511c5fdf3342bda6c1b886154258932b9ffc219