### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Accountsync/BAO/AccountContact.php
+++ b/CRM/Accountsync/BAO/AccountContact.php
@@ -14,7 +14,7 @@ class CRM_Accountsync_BAO_AccountContact extends CRM_Accountsync_DAO_AccountCont
     $entityName = 'AccountContact';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
 

--- a/CRM/Accountsync/BAO/AccountInvoice.php
+++ b/CRM/Accountsync/BAO/AccountInvoice.php
@@ -18,7 +18,7 @@ class CRM_Accountsync_BAO_AccountInvoice extends CRM_Accountsync_DAO_AccountInvo
     $entityName = 'AccountInvoice';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();

--- a/accountsync.php
+++ b/accountsync.php
@@ -250,7 +250,7 @@ function _accountsync_validate_for_connector($connector_id, $financial_type_id) 
   if (!isset($connector_financial_types[$financial_type_id])) {
     $connector_financial_types[$financial_type_id] = CRM_Accountsync_BAO_AccountInvoice::getAccountsContact($financial_type_id);
   }
-  if ($accounts_contact_id == CRM_Utils_Array::value($financial_type_id, $connector_financial_types)) {
+  if ($accounts_contact_id == ($connector_financial_types[$financial_type_id] ?? NULL)) {
     return TRUE;
   }
   else {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.