### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/AccountContact.php
+++ b/api/v3/AccountContact.php
@@ -6,7 +6,7 @@
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_contact_create($params) {
   return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountContact', $params);
@@ -46,7 +46,7 @@ function civicrm_api3_account_contact_link($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_contact_delete($params) {
   return _civicrm_api3_basic_delete('CRM_Accountsync_BAO_AccountContact', $params);
@@ -58,7 +58,7 @@ function civicrm_api3_account_contact_delete($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_contact_get($params) {
   $accountContacts = _civicrm_api3_basic_get('CRM_Accountsync_BAO_AccountContact', $params);
@@ -83,7 +83,7 @@ function civicrm_api3_account_contact_get($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_contact_getsuggestions($params) {
   $contacts = civicrm_api3('AccountContact', 'get', array_merge($params, [

--- a/api/v3/AccountInvoice.php
+++ b/api/v3/AccountInvoice.php
@@ -7,7 +7,7 @@
  *
  * @return array
  *   API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_invoice_create($params) {
   return _civicrm_api3_basic_create('CRM_Accountsync_BAO_AccountInvoice', $params);
@@ -21,7 +21,7 @@ function civicrm_api3_account_invoice_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_invoice_delete($params) {
   return _civicrm_api3_basic_delete('CRM_Accountsync_BAO_AccountInvoice', $params);
@@ -35,7 +35,7 @@ function civicrm_api3_account_invoice_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_invoice_get($params) {
   return _civicrm_api3_basic_get('CRM_Accountsync_BAO_AccountInvoice', $params);
@@ -67,7 +67,7 @@ function _civicrm_api3_account_invoice_getderived_spec(&$spec) {
  *
  * @return array
  *   API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_invoice_getderived($params) {
   return civicrm_api3_create_success(CRM_Accountsync_BAO_AccountInvoice::getDerived($params));

--- a/api/v3/AccountLineItems.php
+++ b/api/v3/AccountLineItems.php
@@ -19,7 +19,7 @@ function _civicrm_api3_account_line_items_create_spec(&$spec) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_line_items_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -31,7 +31,7 @@ function civicrm_api3_account_line_items_create($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_line_items_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -43,7 +43,7 @@ function civicrm_api3_account_line_items_delete($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_line_items_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/AccountPayment.php
+++ b/api/v3/AccountPayment.php
@@ -19,7 +19,7 @@ function _civicrm_api3_account_payment_create_spec(&$spec) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_payment_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -31,7 +31,7 @@ function civicrm_api3_account_payment_create($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_payment_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -43,7 +43,7 @@ function civicrm_api3_account_payment_delete($params) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_account_payment_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.