### PR TITLE
Don't flag completed AccountInvoices for update

### DIFF
--- a/accountsync.php
+++ b/accountsync.php
@@ -647,11 +647,18 @@ function _accountsync_create_account_invoice(int $contributionID, int $connector
     }
     else {
       // We have an existing AccountInvoice record
-      // Flag existing AccountInvoice as needing sync with accounts system.
-      \Civi\Api4\AccountInvoice::update(FALSE)
-        ->setWhere($existingAccountInvoiceWheres)
-        ->addValue('accounts_needs_update', TRUE)
-        ->execute();
+      // We can't update if we have an existing accounts_invoice_id the accounts status is "completed"
+      //   because we (the code) don't know how to update a completed invoice at the accounts system.
+      if (!empty($existingAccountInvoice['accounts_invoice_id'])
+        && ($existingAccountInvoice['account_status_id:name'] !== 'completed')) {
+        // Our AccountInvoice is not marked completed in the accounts system so we can update it.
+        // (If accounts_invoice_id is empty then it doesn't exist in the accounts system)
+        // Flag existing AccountInvoice as needing sync with accounts system.
+        \Civi\Api4\AccountInvoice::update(FALSE)
+          ->setWhere($existingAccountInvoiceWheres)
+          ->addValue('accounts_needs_update', TRUE)
+          ->execute();
+      }
     }
   }
 }

--- a/accountsync.php
+++ b/accountsync.php
@@ -144,7 +144,7 @@ function accountsync_civicrm_post(string $op, string $objectName, $objectId, &$o
         continue;
       }
       // we won't do updates as the invoices get 'locked' in the accounts system
-      _accountsync_create_account_invoice($contribution_id, TRUE, $connector_id);
+      _accountsync_create_account_invoice($contribution_id, $connector_id);
     }
   }
 
@@ -153,7 +153,7 @@ function accountsync_civicrm_post(string $op, string $objectName, $objectId, &$o
 /**
  * Is the invoice before the day zero.
  *
- * We only sync contributions afer the day zero date.
+ * We only sync contributions after the day zero date.
  *
  * @param string $objectName
  * @param CRM_Contribute_BAO_Contribution|CRM_Price_BAO_LineItem $objectRef
@@ -615,45 +615,43 @@ function _accountsync_create_account_contact($contactID, $createNew, $connector_
  * Create account invoice record or set needs_update flag.
  *
  * @param int $contributionID
- * @param bool $createNew
  * @param int $connector_id
  *   ID of connector for civicrm_connector if nz.co.fuzion.connectors enabled.
  *   Otherwise this will be 0.
+ *
+ * @return void
+ * @throws \CRM_Core_Exception
+ * @throws \Civi\API\Exception\UnauthorizedException
  */
-function _accountsync_create_account_invoice($contributionID, $createNew, $connector_id) {
-  $accountInvoice = [
-    'contribution_id' => $contributionID,
-    'accounts_needs_update' => 1,
-    // Do not rollback on fail.
-    'is_transactional' => FALSE,
-  ];
+function _accountsync_create_account_invoice(int $contributionID, int $connector_id): void {
   foreach (_accountsync_get_enabled_plugins() as $plugin) {
-    unset($accountInvoice['id']); // Ensure id is not set in case of multiple plugins
-
-    if ($connector_id) {
-      $accountInvoice['connector_id'] = $connector_id;
+    // Check for existing AccountInvoice
+    $existingAccountInvoiceWheres = [
+      ['plugin', '=', $plugin],
+      ['connector_id', '=', $connector_id],
+      ['contribution_id', '=', $contributionID],
+    ];
+    $existingAccountInvoice = \Civi\Api4\AccountInvoice::get(FALSE)
+      ->addSelect('id', 'accounts_invoice_id', 'accounts_status_id:name')
+      ->setWhere($existingAccountInvoiceWheres)
+      ->execute()
+      ->first();
+    if (empty($existingAccountInvoice)) {
+      // Create new AccountInvoice record and flag as needing sync with accounts system
+      \Civi\Api4\AccountInvoice::create(FALSE)
+        ->addValue('plugin', $plugin)
+        ->addValue('connector_id', $connector_id)
+        ->addValue('contribution_id', $contributionID)
+        ->addValue('accounts_needs_update', TRUE)
+        ->execute();
     }
-    try {
-      $accountInvoice['id'] = civicrm_api3('AccountInvoice', 'getvalue', [
-        'plugin' => $plugin,
-        'return' => 'id',
-        'contribution_id' => $contributionID,
-        'connector_id' => $connector_id,
-      ]);
-    }
-    catch (CRM_Core_Exception $e) {
-      // new invoice
-      if (!$createNew) {
-        continue;
-      }
-    }
-    $accountInvoice['plugin'] = $plugin;
-    try {
-      civicrm_api3('AccountInvoice', 'create', $accountInvoice);
-    }
-    catch (CRM_Core_Exception $e) {
-      // Unknown failure.
-      \Civi::log('account_sync')->info('issue creating account invoice' . $e->getMessage());
+    else {
+      // We have an existing AccountInvoice record
+      // Flag existing AccountInvoice as needing sync with accounts system.
+      \Civi\Api4\AccountInvoice::update(FALSE)
+        ->setWhere($existingAccountInvoiceWheres)
+        ->addValue('accounts_needs_update', TRUE)
+        ->execute();
     }
   }
 }


### PR DESCRIPTION
Following this change to https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/pull/194 it exposes an issue in accountsync where "completed" AccountInvoices are still flagged as needing update when the Contribution in CiviCRM is updated (eg. a receipt_date is added).

I wasn't sure if this check belonged in accountsync or in Xero push code, but if in Xero we'd have to do the same check and set it back to accounts_need_update = FALSE which seems a bit late in the process - unless other accountsync plugins are able to sync changes to completed contributions back to the account system.

The first commit is refactor only (simplify and convert to API4).

Second commit is the actual change - alternative for the second commit is here: https://github.com/eileenmcnaughton/nz.co.fuzion.civixero/pull/194/changes/2f0c2ce039015cb3a2d4f25a51f532df38ff11f2